### PR TITLE
Add mechanisms for retrying fetching data

### DIFF
--- a/FCNameColor/Configuration.cs
+++ b/FCNameColor/Configuration.cs
@@ -15,21 +15,21 @@ namespace FCNameColor
         public bool OnlyColorFCTag { get; set; } = true;
         public bool IncludeSelf { get; set; } = true;
         public bool IncludeDuties { get; set; } = true;
-        public bool Glow { get; set; } = false;
-        public Vector4 Color { get; set; } = new Vector4(0.8f, 0.21568628f, 0.21568628f, 1.0f); // The same as UiColor 14.
+        public bool Glow { get; set; }
+        public Vector4 Color { get; set; } = new(0.8f, 0.21568628f, 0.21568628f, 1.0f); // The same as UiColor 14.
         public string UiColor { get; set; } = "14"; // A red-ish colour.
 
         /// <summary>
         /// A mapping of character Name@Server and character IDs
         /// </summary>
-        public Dictionary<string, string> PlayerIDs { get; set; } = new Dictionary<string, string>();
+        public Dictionary<string, string> PlayerIDs { get; set; } = new();
 
         /// <summary>
         /// A mapping of Player ID and their FC’s ID
         /// </summary>
-        public Dictionary<string, FC> PlayerFCs { get; set; } = new Dictionary<string, FC>();
+        public Dictionary<string, FC> PlayerFCs { get; set; } = new();
 
-        public Dictionary<string, string> IgnoredPlayers { get; set; } = new Dictionary<string, string>();
+        public Dictionary<string, string> IgnoredPlayers { get; set; } = new();
 
         [NonSerialized]
         private DalamudPluginInterface pluginInterface;

--- a/FCNameColor/FCNameColor.csproj
+++ b/FCNameColor/FCNameColor.csproj
@@ -6,8 +6,8 @@
         <AssemblyTitle>FCNameColor</AssemblyTitle>
         <Product>FCNameColor</Product>
         <Copyright>Copyright © 2021</Copyright>
-        <AssemblyVersion>2.0.1.0</AssemblyVersion>
-        <FileVersion>2.0.1.0</FileVersion>
+        <AssemblyVersion>2.0.2.0</AssemblyVersion>
+        <FileVersion>2.0.2.0</FileVersion>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <OutputPath>bin\$(Configuration)\</OutputPath>
         <PreserveCompilationContext>false</PreserveCompilationContext>

--- a/FCNameColor/Plugin.cs
+++ b/FCNameColor/Plugin.cs
@@ -190,25 +190,16 @@ namespace FCNameColor
                 config.PlayerIDs[playerCacheName] = playerId;
             }
 
-            var fcFetched = config.PlayerFCs.TryGetValue(playerId, out var fc);
-            if (!fcFetched)
+            PluginLog.Debug("Fetching FC ID via character page");
+            var player = await lodestoneClient.GetCharacter(playerId);
+            if (player.FreeCompany == null)
             {
-                PluginLog.Debug("Fetching FC ID via character page");
-                var player = await lodestoneClient.GetCharacter(playerId);
-                if (player.FreeCompany == null)
-                {
-                    PluginLog.Debug("Player is not in an FC.");
-                    NotInFC = true;
-                    return;
-                }
+                PluginLog.Debug("Player is not in an FC.");
+                NotInFC = true;
+                return;
+            }
 
-                fc = new FC {ID = player.FreeCompany.Id, Name = player.FreeCompany.Name};
-            }
-            else
-            {
-                PluginLog.Debug($"Loading {fc.Members.Length} cached FC members");
-                members = fc.Members.ToList();
-            }
+            var fc = new FC {ID = player.FreeCompany.Id, Name = player.FreeCompany.Name};
 
             // Fetch the first page of FC members.
             // This will also contain the amount of additional pages of members that may have to be retrieved.

--- a/FCNameColor/Plugin.cs
+++ b/FCNameColor/Plugin.cs
@@ -190,6 +190,13 @@ namespace FCNameColor
                 config.PlayerIDs[playerCacheName] = playerId;
             }
 
+            var fcFetched = config.PlayerFCs.TryGetValue(playerId, out var cachedFC);
+            if (fcFetched)
+            {
+                PluginLog.Debug($"Loading {cachedFC.Members.Length} cached FC members");
+                members = cachedFC.Members.ToList();
+            }
+
             PluginLog.Debug("Fetching FC ID via character page");
             var player = await lodestoneClient.GetCharacter(playerId);
             if (player.FreeCompany == null)


### PR DESCRIPTION
Changes:
* Add more feedback when something went wrong with fetching data
* Add auto-retry function. When the plugin loads and runs into an error, it will retry every 20 seconds.
* Add Clear & Retry button. This can be used to manually retrigger loading the FC and its members.
* Update fetch data function to always fetch the player’s FC. This causes the initial setup to take a little longer, but it should handle players switching their FCs better.