### PR TITLE
Remove verbose logging for release builds

### DIFF
--- a/FCNameColor/FCNameColor.csproj
+++ b/FCNameColor/FCNameColor.csproj
@@ -6,8 +6,8 @@
     <AssemblyTitle>FCNameColor</AssemblyTitle>
     <Product>FCNameColor</Product>
     <Copyright>Copyright © 2023</Copyright>
-    <AssemblyVersion>3.0.1.1</AssemblyVersion>
-    <FileVersion>3.0.1.1</FileVersion>
+    <AssemblyVersion>3.0.1.2</AssemblyVersion>
+    <FileVersion>3.0.1.2</FileVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <PreserveCompilationContext>false</PreserveCompilationContext>

--- a/FCNameColor/FCNameColor.json
+++ b/FCNameColor/FCNameColor.json
@@ -5,7 +5,7 @@
   "CategoryTags": [ "ui", "social" ],
   "Description": "Color your FC’s tag or the entire nameplate if they are in your FC or other specified FCs.\nWorks using Lodestone data, so it can continue working inside duties as well as on different servers!",
   "InternalName": "FCNameColor",
-  "AssemblyVersion": "3.0.1.1",
+  "AssemblyVersion": "3.0.1.2",
   "RepoUrl": "https://github.com/WesselKuipers/FCNameColor",
   "IconUrl": "https://github.com/WesselKuipers/FCNameColor/raw/main/images/icon.png",
   "Tags": [ "nameplate", "FC", "name", "colors" ],

--- a/FCNameColor/Plugin.cs
+++ b/FCNameColor/Plugin.cs
@@ -597,7 +597,10 @@ namespace FCNameColor
                 }
             }
 
+#if DEBUG
             PluginLog.Verbose("Overriding player nameplate for {name} (ObjectID {objectID})", name, objectID);
+#endif
+
             return original();
         }
 


### PR DESCRIPTION
This was causing excessive log entries for other developers, so now it'll only be included in debug builds.